### PR TITLE
[next.js] Fix global.d.ts

### DIFF
--- a/src/nextjs/global.d.ts
+++ b/src/nextjs/global.d.ts
@@ -27,7 +27,7 @@ declare namespace React {
       'dap-ds-content-switcher': import('dap-design-system/dist/react-types').DapDSContentSwitcherType
       'dap-ds-copybox-input': import('dap-design-system/dist/react-types').DapDSCopyBoxInputType
       'dap-ds-datatable': import('dap-design-system/dist/react-types').DapDSDataTableType
-      'dap-ds-dap-badge': import('dap-design-system/dist/react-types').DapDSBadgeType
+      'dap-ds-dap-badge': import('dap-design-system/dist/react-types').DapDSDAPBadgeType
       'dap-ds-datepicker': import('dap-design-system/dist/react-types').DapDSDatePickerType
       'dap-ds-divider': import('dap-design-system/dist/react-types').DapDSDividerType
       'dap-ds-feedback': import('dap-design-system/dist/react-types').DapDSFeedbackType


### PR DESCRIPTION
https://services.gov.hu/design-system-dev/frameworks/react19#typing has a typo in it for the `dap-ds-dap-badge` component's type.